### PR TITLE
Fix missing dependencies when running frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,12 @@ services:
     image: llama-chat-frontend
     volumes:
       - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
     ports:
       - "3000:3000"
     environment:
       - VITE_API_URL=http://localhost:8000
     command: ["npm", "run", "dev", "--", "--host"]
+
+volumes:
+  frontend_node_modules:


### PR DESCRIPTION
## Summary
- mount a volume for frontend `node_modules`

This ensures the dependencies installed during build are preserved when the
frontend code directory is mounted during `docker compose up`, preventing the
"vite: not found" error.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68787f24e000832ba7059f7b40d8f22b