### PR TITLE
Implement simple chat frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Llama Chat</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,48 @@
-#root {
-  max-width: 1280px;
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-width: 600px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.messages {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.message {
+  margin-bottom: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  max-width: 80%;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.message.user {
+  align-self: flex-end;
+  background-color: #d1e8ff;
 }
 
-.card {
-  padding: 2em;
+.message.bot {
+  align-self: flex-start;
+  background-color: #eee;
 }
 
-.read-the-docs {
-  color: #888;
+.input-area {
+  display: flex;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-top: 1px solid #ccc;
+}
+
+.input-area textarea {
+  flex: 1;
+  resize: none;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+.input-area button {
+  padding: 0.5rem 1rem;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,34 +1,58 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [messages, setMessages] = useState([])
+  const [input, setInput] = useState('')
+  const apiUrl = import.meta.env.VITE_API_URL || ''
+
+  const sendMessage = async () => {
+    const text = input.trim()
+    if (!text) return
+    const userMsg = { role: 'user', content: text }
+    setMessages((m) => [...m, userMsg])
+    setInput('')
+    try {
+      const res = await fetch(`${apiUrl}/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+      })
+      const data = await res.json()
+      setMessages((m) => [...m, { role: 'assistant', content: data.response }])
+    } catch (err) {
+      setMessages((m) => [
+        ...m,
+        { role: 'assistant', content: 'Error: ' + err.message }
+      ])
+    }
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+    }
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <div className="chat-container">
+      <div className="messages">
+        {messages.map((m, i) => (
+          <div key={i} className={`message ${m.role === 'user' ? 'user' : 'bot'}`}>{m.content}</div>
+        ))}
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
+      <div className="input-area">
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={2}
+          placeholder="Type your message..."
+        />
+        <button onClick={sendMessage}>Send</button>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    </div>
   )
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- build minimal ChatGPT-like chat interface in React
- add styles for chat layout
- adjust page title and remove centering from global CSS

## Testing
- `npm install`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68788f4a1760832b894c14b2ec1a1cd1