### PR TITLE
Add local llama backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Llama Chat is a chat application that illustrates how a lightweight web frontend
 
 Backend variables:
 
-- `REPLICATE_API_TOKEN` – API token for Replicate
-- `LLAMA_MODEL` – Model reference to use (defaults to `llama4:maverick`)
+- `REPLICATE_API_TOKEN` – API token for Replicate (used when `LLAMA_MODEL_PATH` is not set)
+- `LLAMA_MODEL` – Model reference to use with Replicate (defaults to `llama4:maverick`)
+- `LLAMA_MODEL_PATH` – Path to a local GGUF model file; if provided the backend runs locally using `llama-cpp`
 - `PORT` – Port for the backend server (defaults to `8000`)
 
 Frontend variables:
@@ -47,10 +48,14 @@ Frontend variables:
 Create a `.env` file in each component with values similar to the example below:
 
 ```
+# Example using Replicate
 REPLICATE_API_TOKEN=your-token
 LLAMA_MODEL=llama4:maverick
 PORT=8000
 VITE_API_URL=http://localhost:8000
+
+# Example using a local model
+# LLAMA_MODEL_PATH=/path/to/model.gguf
 ```
 
 ## Setup and Running Locally
@@ -70,6 +75,8 @@ source venv/bin/activate
 pip install -r requirements.txt
 uvicorn app.main:app --reload --port $PORT
 ```
+If `LLAMA_MODEL_PATH` is set to a local GGUF file, the backend will load it
+using `llama-cpp` instead of contacting Replicate.
 
 ### Frontend
 
@@ -105,7 +112,7 @@ Both methods start the services and expose the web UI at `http://localhost:3000`
 
 - Implemented with FastAPI (or a similar framework)
 - Provides endpoints to submit user messages and stream responses
-- Relays authentication and requests to the LLM provider
+- Relays authentication and requests to the LLM provider or runs a local model when `LLAMA_MODEL_PATH` is set
 
 ## Contributing
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,11 +3,26 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import replicate
 
+try:
+    from llama_cpp import Llama
+except ImportError:  # pragma: no cover - optional dependency
+    Llama = None
+
 app = FastAPI(title="Llama Chat Backend")
+
+# Local model path enables llama.cpp backend
+LLAMA_MODEL_PATH = os.getenv("LLAMA_MODEL_PATH")
 
 # Default model reference for Replicate
 LLAMA_MODEL = os.getenv("LLAMA_MODEL", "llama4:maverick")
-client = replicate.Client(api_token=os.getenv("REPLICATE_API_TOKEN"))
+
+if LLAMA_MODEL_PATH:
+    if Llama is None:
+        raise RuntimeError("llama-cpp-python must be installed for local mode")
+    llm = Llama(model_path=LLAMA_MODEL_PATH)
+    client = None
+else:
+    client = replicate.Client(api_token=os.getenv("REPLICATE_API_TOKEN"))
 
 class Message(BaseModel):
     text: str
@@ -18,6 +33,14 @@ async def root():
 
 @app.post("/chat")
 async def chat(msg: Message):
+    if LLAMA_MODEL_PATH:
+        try:
+            result = llm(msg.text, max_tokens=128)
+            output = result["choices"][0]["text"]
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+        return {"response": output.strip()}
+
     if client._api_token is None:
         raise HTTPException(status_code=500, detail="REPLICATE_API_TOKEN not configured")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pydantic
 replicate
+llama-cpp-python


### PR DESCRIPTION
## Summary
- add optional llama.cpp backend for local model execution
- document LLAMA_MODEL_PATH variable
- include llama-cpp-python in requirements

## Testing
- `python -m py_compile backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6878915d12e4832b90620815b565db25